### PR TITLE
Ensure new service worker version activates on refresh

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -18,25 +18,23 @@ self.addEventListener('install', (event) => {
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys
-            .filter(
-              (key) =>
-                key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME
-            )
-            .map((key) => caches.delete(key))
-        )
-      )
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter(
+            (key) => key.startsWith(CACHE_PREFIX) && key !== CACHE_NAME
+          )
+          .map((key) => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
   );
-  self.clients.claim();
 });
 
 self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
+    event.waitUntil(self.skipWaiting());
   }
 });
 


### PR DESCRIPTION
## Summary
- wait for cache cleanup and client claiming during service worker activation so updates control the page
- keep the service worker alive while handling the SKIP_WAITING message to finish activation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d41a4a58e8832b8bc580f58980f6db