### PR TITLE
Remove prefix from today's quote date label

### DIFF
--- a/script.js
+++ b/script.js
@@ -506,7 +506,7 @@ function renderQuote(text, dateKey) {
   if (formattedDate) {
     const label =
       dateKey === getTodayKey()
-        ? `Dzisiejszy cytat — ${formattedDate}`
+        ? formattedDate
         : `Ostatnio zapisany cytat — ${formattedDate}`;
     elements.quoteDate.textContent = label;
   } else {


### PR DESCRIPTION
## Summary
- remove the "Dzisiejszy cytat —" prefix when displaying today's quote so that only the date is shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d41a32096c832b830722fb4355e310