### PR TITLE
Add privacy note to Google Sheet URL modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,14 @@
             inputmode="url"
             autocomplete="off"
             placeholder="https://docs.google.com/.../pub?output=csv"
+            aria-describedby="privacy-note url-error"
             required
           />
+          <p id="privacy-note" class="modal-privacy-note">
+            „Maksymalna prywatność. Nie tworzymy kont, nie zbieramy danych.
+            Twoje treści zostają tylko na Twoim komputerze – nic nie trafia na
+            serwer ani do chmury.”
+          </p>
           <p id="url-error" class="url-error" role="alert" aria-live="assertive"></p>
           <button type="submit" class="modal-submit">Zapisz</button>
         </form>

--- a/styles.css
+++ b/styles.css
@@ -222,6 +222,13 @@ main.app {
   box-shadow: 0 0 0 4px rgba(26, 26, 26, 0.2);
 }
 
+.modal-privacy-note {
+  margin: -0.25rem 0 0;
+  color: #4a4a4a;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
 .modal-submit {
   padding: 0.9rem;
   border: none;


### PR DESCRIPTION
## Summary
- add a privacy assurance note below the Google Sheet URL field in the setup modal
- style the new note with a slightly smaller font and subtle coloring to differentiate it from the main instructions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4278c8f50832b846d5c454134974a